### PR TITLE
Updated ember-cli-babel dep for deprecation fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test:all": "ember try:each"
   },
   "dependencies": {
-    "ember-cli-babel": "^6.6.0"
+    "ember-cli-babel": "^8.2.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",


### PR DESCRIPTION
Linked to [VEL-4674](https://linear.app/upfluence/issue/VEL-4674/httpsdeprecationsemberjscomv3xtoc-ember-global)
Manually bumped ember-cli-babel version to 8.2.0 in package.json, in order to fix ember global deprecation.